### PR TITLE
Switch to single 'parent' variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ module "folders" {
   source  = "terraform-google-modules/folders/google"
   version = "~> 0.1"
 
-  parent_id   = "65552901371"
-  parent_type = "folder"
+  parent  = "folders/65552901371"
 
   names = [
     "dev",
@@ -59,8 +58,7 @@ Functional examples are included in the
 | all\_folder\_admins | List of IAM-style members that will get the extended permissions across all the folders. | list | `<list>` | no |
 | folder\_admin\_roles | List of roles that will be applied to per folder owners on their respective folder. | list | `<list>` | no |
 | names | Folder names. | list | `<list>` | no |
-| parent\_id | Id of the resource under which the folder will be placed. | string | n/a | yes |
-| parent\_type | Type of the parent reosurce, defaults to organization. | string | `"organization"` | no |
+| parent | Path of the resource under which the folder will be placed (eg folders/12345). | string | `""` | no |
 | per\_folder\_admins | List of IAM-style members per folder who will get extended permissions. | list | `<list>` | no |
 | prefix | Optional prefix to enforce uniqueness of folder names. | string | `""` | no |
 | set\_roles | Set roles to actors passed in role_members variable. | string | `"false"` | no |

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -21,8 +21,7 @@ provider "google" {
 module "folders" {
   source = "../.."
 
-  parent_id         = var.parent_id
-  parent_type       = var.parent_type
+  parent            = var.parent
   names             = var.names
   set_roles         = true
   per_folder_admins = var.per_folder_admins

--- a/examples/simple_example/variables.tf
+++ b/examples/simple_example/variables.tf
@@ -14,15 +14,9 @@
  * limitations under the License.
  */
 
-variable "parent_id" {
+variable "parent" {
   type        = string
-  description = "Id of the resource under which the folder will be placed."
-}
-
-variable "parent_type" {
-  type        = string
-  description = "Type of the parent reosurce, defaults to organization."
-  default     = "folder"
+  description = "Path of the resource under which the folder will be placed."
 }
 
 variable "names" {

--- a/main.tf
+++ b/main.tf
@@ -25,23 +25,23 @@ locals {
 resource "google_folder" "folders" {
   count        = length(var.names)
   display_name = "${local.prefix}${element(var.names, count.index)}"
-  parent       = "${var.parent_type}s/${var.parent_id}"
+  parent       = var.parent
 }
 
 # give project creation access to service accounts
 # https://cloud.google.com/resource-manager/docs/access-control-folders#granting_folder-specific_roles_to_enable_project_creation
 
 resource "google_folder_iam_binding" "owners" {
-  count = var.set_roles ? length(var.names) * length(var.folder_admin_roles) : 0
+  count  = var.set_roles ? length(var.names) * length(var.folder_admin_roles) : 0
   folder = google_folder.folders[floor(count.index / length(var.folder_admin_roles))].name
-  role = var.folder_admin_roles[count.index % length(var.folder_admin_roles)]
+  role   = var.folder_admin_roles[count.index % length(var.folder_admin_roles)]
 
   members = compact(
-              concat(
-                split(",",
-                  concat(var.per_folder_admins, [""])[floor(count.index / length(var.folder_admin_roles))],
-                ), var.all_folder_admins,
-              ),
-            )
+    concat(
+      split(",",
+        concat(var.per_folder_admins, [""])[floor(count.index / length(var.folder_admin_roles))],
+      ), var.all_folder_admins,
+    ),
+  )
 }
 

--- a/test/fixtures/simple_example/main.tf
+++ b/test/fixtures/simple_example/main.tf
@@ -21,7 +21,7 @@ provider "random" {
 module "example" {
   source = "../../../examples/simple_example"
 
-  parent_id         = var.parent_id
+  parent            = var.parent
   names             = var.names
   per_folder_admins = var.per_folder_admins
   all_folder_admins = var.all_folder_admins

--- a/test/fixtures/simple_example/outputs.tf
+++ b/test/fixtures/simple_example/outputs.tf
@@ -21,12 +21,7 @@ output "names_and_ids" {
 
 output "parent_id" {
   description = "Id of the resource under which the folder will be placed."
-  value       = var.parent_id
-}
-
-output "parent_type" {
-  description = "Type of the parent reosurce, defaults to organization."
-  value       = var.parent_type
+  value       = element(split("/", var.parent), 1)
 }
 
 output "names" {

--- a/test/fixtures/simple_example/variables.tf
+++ b/test/fixtures/simple_example/variables.tf
@@ -14,15 +14,9 @@
  * limitations under the License.
  */
 
-variable "parent_id" {
+variable "parent" {
   type        = string
-  description = "Id of the resource under which the folder will be placed."
-}
-
-variable "parent_type" {
-  type        = string
-  description = "Type of the parent reosurce, defaults to organization."
-  default     = "folder"
+  description = "Path of the resource under which the folder will be placed."
 }
 
 variable "names" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,15 +14,9 @@
  * limitations under the License.
  */
 
-variable "parent_id" {
+variable "parent" {
   type        = string
-  description = "Id of the resource under which the folder will be placed."
-}
-
-variable "parent_type" {
-  type        = string
-  description = "Type of the parent reosurce, defaults to organization."
-  default     = "organization"
+  description = "Path of the resource under which the folder will be placed (eg folders/12345)."
 }
 
 variable "names" {
@@ -50,7 +44,7 @@ variable "all_folder_admins" {
 }
 
 variable "prefix" {
-  type = string
+  type        = string
   description = "Optional prefix to enforce uniqueness of folder names."
   default     = ""
 }


### PR DESCRIPTION
Switch from `parent_type` + `parent_id` variables to a single `parent` variable.

Fixes #6 