### PR TITLE
use for_each instead of count to create folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.12.0
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ module "folders" {
 
   set_roles = true
 
-  per_folder_admins = [
-    "group:gcp-developers@domain.com",
-    "group:gcp-qa@domain.com",
-    "group:gcp-ops@domain.com",
-  ]
+  per_folder_admins = {
+    dev = "group:gcp-developers@domain.com"
+    staging = "group:gcp-qa@domain.com"
+    production = "group:gcp-ops@domain.com"
+  }
 
   all_folder_admins = [
     "group:gcp-security@domain.com",
@@ -57,7 +57,7 @@ Functional examples are included in the
 | folder\_admin\_roles | List of roles that will be applied to per folder owners on their respective folder. | list(string) | `<list>` | no |
 | names | Folder names. | list(string) | `<list>` | no |
 | parent | The resource name of the parent Folder or Organization. Must be of the form folders/folder_id or organizations/org_id | string | n/a | yes |
-| per\_folder\_admins | List of IAM-style members per folder who will get extended permissions. | list(string) | `<list>` | no |
+| per\_folder\_admins | IAM-style members per folder who will get extended permissions. | map(string) | `<map>` | no |
 | prefix | Optional prefix to enforce uniqueness of folder names. | string | `""` | no |
 | set\_roles | Enable setting roles via the folder admin variables. | bool | `"false"` | no |
 
@@ -66,7 +66,8 @@ Functional examples are included in the
 | Name | Description |
 |------|-------------|
 | folder | Folder resource (for single use). |
-| folders | Folder resources. |
+| folders | Folder resources as list. |
+| folders\_map | Folder resources by name. |
 | id | Folder id (for single use). |
 | ids | Folder ids. |
 | ids\_list | List of folder ids. |

--- a/examples/simple_example/README.md
+++ b/examples/simple_example/README.md
@@ -11,7 +11,7 @@ This example illustrates how to use the `folders` module.
 | names | Folder names. | list(string) | `<list>` | no |
 | parent\_id | Id of the resource under which the folder will be placed. | string | n/a | yes |
 | parent\_type | Type of the parent resource. One of `organizations` or `folders`. | string | `"folders"` | no |
-| per\_folder\_admins | List of IAM-style members per folder who will get extended permissions. | list(string) | `<list>` | no |
+| per\_folder\_admins | IAM-style members per folder who will get extended permissions. | map(string) | `<map>` | no |
 
 ## Outputs
 
@@ -20,6 +20,7 @@ This example illustrates how to use the `folders` module.
 | ids | Folder ids. |
 | ids\_list | List of folder ids. |
 | names | Folder names. |
+| names\_list | List of folder names. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.36.0"
+  version = "~> 3.38.0"
 }
 
 module "folders" {

--- a/examples/simple_example/outputs.tf
+++ b/examples/simple_example/outputs.tf
@@ -28,3 +28,8 @@ output "ids_list" {
   description = "List of folder ids."
   value       = module.folders.ids_list
 }
+
+output "names_list" {
+  description = "List of folder names."
+  value       = module.folders.names_list
+}

--- a/examples/simple_example/variables.tf
+++ b/examples/simple_example/variables.tf
@@ -32,9 +32,9 @@ variable "names" {
 }
 
 variable "per_folder_admins" {
-  type        = list(string)
-  description = "List of IAM-style members per folder who will get extended permissions."
-  default     = []
+  type        = map(string)
+  description = "IAM-style members per folder who will get extended permissions."
+  default     = {}
 }
 
 variable "all_folder_admins" {

--- a/main.tf
+++ b/main.tf
@@ -19,12 +19,24 @@ terraform {
 }
 
 locals {
-  prefix = var.prefix == "" ? "" : "${var.prefix}-"
+  prefix       = var.prefix == "" ? "" : "${var.prefix}-"
+  folders_list = [for name in var.names : google_folder.folders[name]]
+  first_folder = local.folders_list[0]
+
+  name_role_pairs = setproduct(var.names, var.folder_admin_roles)
+  folder_admin_roles_map_data = zipmap(
+    [for pair in local.name_role_pairs : "${pair[0]}-${pair[1]}"],
+    [for pair in local.name_role_pairs : {
+      name = pair[0]
+      role = pair[1]
+    }]
+  )
 }
 
 resource "google_folder" "folders" {
-  count        = length(var.names)
-  display_name = "${local.prefix}${element(var.names, count.index)}"
+  for_each = toset(var.names)
+
+  display_name = "${local.prefix}${each.value}"
   parent       = var.parent
 }
 
@@ -32,15 +44,16 @@ resource "google_folder" "folders" {
 # https://cloud.google.com/resource-manager/docs/access-control-folders#granting_folder-specific_roles_to_enable_project_creation
 
 resource "google_folder_iam_binding" "owners" {
-  count  = var.set_roles ? length(var.names) * length(var.folder_admin_roles) : 0
-  folder = google_folder.folders[floor(count.index / length(var.folder_admin_roles))].name
-  role   = var.folder_admin_roles[count.index % length(var.folder_admin_roles)]
+  for_each = var.set_roles ? local.folder_admin_roles_map_data : {}
+  folder   = google_folder.folders[each.value.name].name
+  role     = each.value.role
 
   members = compact(
     concat(
       split(",",
-        concat(var.per_folder_admins, [""])[floor(count.index / length(var.folder_admin_roles))],
-      ), var.all_folder_admins,
+        lookup(var.per_folder_admins, each.value.name, ""),
+      ),
+      var.all_folder_admins,
     ),
   )
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,40 +16,49 @@
 
 output "folder" {
   description = "Folder resource (for single use)."
-  value       = google_folder.folders[0]
+  value       = local.first_folder
 }
 
 output "id" {
   description = "Folder id (for single use)."
-  value       = google_folder.folders[0].name
+  value       = local.first_folder.name
 }
 
 output "name" {
   description = "Folder name (for single use)."
-  value       = google_folder.folders[0].display_name
+  value       = local.first_folder.display_name
 }
 
 output "folders" {
-  description = "Folder resources."
+  description = "Folder resources as list."
+  value       = local.folders_list
+}
+
+output "folders_map" {
+  description = "Folder resources by name."
   value       = google_folder.folders
 }
 
 output "ids" {
   description = "Folder ids."
-  value       = zipmap(var.names, slice(google_folder.folders[*].name, 0, length(var.names)))
+  value = { for name, folder in google_folder.folders :
+    name => folder.name
+  }
 }
 
 output "names" {
   description = "Folder names."
-  value       = zipmap(var.names, slice(google_folder.folders[*].display_name, 0, length(var.names)))
+  value = { for name, folder in google_folder.folders :
+    name => folder.display_name
+  }
 }
 
 output "ids_list" {
   description = "List of folder ids."
-  value       = google_folder.folders[*].name
+  value       = local.folders_list[*].name
 }
 
 output "names_list" {
   description = "List of folder names."
-  value       = google_folder.folders[*].display_name
+  value       = local.folders_list[*].display_name
 }

--- a/test/fixtures/simple_example/outputs.tf
+++ b/test/fixtures/simple_example/outputs.tf
@@ -24,6 +24,11 @@ output "ids_list" {
   value       = module.example.ids_list
 }
 
+output "names_list" {
+  description = "List of folder names."
+  value       = module.example.names_list
+}
+
 output "parent_id" {
   description = "Id of the resource under which the folder will be placed."
   value       = var.parent_id
@@ -35,7 +40,7 @@ output "parent_type" {
 }
 
 output "per_folder_admins" {
-  description = "List of IAM-style members per folder who will get extended permissions."
+  description = "IAM-style members per folder who will get extended permissions."
   value       = var.per_folder_admins
 }
 

--- a/test/fixtures/simple_example/variables.tf
+++ b/test/fixtures/simple_example/variables.tf
@@ -39,9 +39,9 @@ variable "per_folder_admins" {
   type        = map(string)
   description = "List of IAM-style members per folder who will get extended permissions."
   default = {
-    dev        = "group:gcp-ddt-developers@apszaz.com",
-    staging    = "group:gcp-ddt-qa@apszaz.com",
-    production = "group:gcp-ddt-ops@apszaz.com",
+    dev        = "group:test-gcp-developers@test.infra.cft.tips",
+    staging    = "group:test-gcp-qa@test.infra.cft.tips",
+    production = "group:test-gcp-ops@test.infra.cft.tips",
   }
 }
 

--- a/test/fixtures/simple_example/variables.tf
+++ b/test/fixtures/simple_example/variables.tf
@@ -36,13 +36,13 @@ variable "names" {
 }
 
 variable "per_folder_admins" {
-  type        = list(string)
+  type        = map(string)
   description = "List of IAM-style members per folder who will get extended permissions."
-  default = [
-    "group:test-gcp-developers@test.infra.cft.tips",
-    "group:test-gcp-qa@test.infra.cft.tips",
-    "group:test-gcp-ops@test.infra.cft.tips",
-  ]
+  default = {
+    dev        = "group:gcp-ddt-developers@apszaz.com",
+    staging    = "group:gcp-ddt-qa@apszaz.com",
+    production = "group:gcp-ddt-ops@apszaz.com",
+  }
 }
 
 variable "all_folder_admins" {

--- a/test/integration/simple_example/controls/gcloud.rb
+++ b/test/integration/simple_example/controls/gcloud.rb
@@ -23,7 +23,7 @@ control "gcloud" do
     its(:stdout) { should include "#{attribute("names").values[2]}" }
   end
 
-  folder_names = attribute("names")
+  folder_names_list = attribute("names_list")
   folder_ids = attribute("ids_list")
   per_folder_admins = attribute("per_folder_admins")
 
@@ -31,7 +31,7 @@ control "gcloud" do
     describe command("gcloud alpha resource-manager folders get-iam-policy #{folder_ids[i]}") do
       its(:exit_status) { should eq 0 }
       its(:stderr) { should eq "" }
-      its(:stdout) { should include per_folder_admins[i] }
+      its(:stdout) { should include per_folder_admins[folder_names_list[i]] }
     end
   end
 

--- a/test/integration/simple_example/inspec.yml
+++ b/test/integration/simple_example/inspec.yml
@@ -13,9 +13,12 @@ attributes:
   - name: ids_list
     required: true
     type: array
-  - name: per_folder_admins
+  - name: names_list
     required: true
     type: array
   - name: per_folder_admins
+    required: true
+    type: hash
+  - name: all_folder_admins
     required: true
     type: array

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.36.0"
+  version = "~> 3.38.0"
 }
 
 provider "google-beta" {
-  version = "~> 3.36.0"
+  version = "~> 3.38.0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,9 +32,9 @@ variable "set_roles" {
 }
 
 variable "per_folder_admins" {
-  type        = list(string)
-  description = "List of IAM-style members per folder who will get extended permissions."
-  default     = []
+  type        = map(string)
+  description = "IAM-style members per folder who will get extended permissions."
+  default     = {}
 }
 
 variable "all_folder_admins" {


### PR DESCRIPTION
This prevents renaming of folders when content/order of the folder names list
changes.

Addresses issue mentioned in: https://github.com/terraform-google-modules/cloud-foundation-fabric/tree/73b7613cc062491305ebfabf8a8b1db0c53fc55b/foundations#things-to-be-aware-of

WARNING: this is a breaking change as the terraform state created before this
change will be incompatible with state expected after the change. This can
be fixed with `terraform state mv`. For example, given the code from the
README.md of this repo, the state would have to be migrated with the following
commands:

```
terraform state mv module.folders.google_folder.folders[0] 'module.folders.google_folder.folders["dev"]'
terraform state mv module.folders.google_folder.folders[1] 'module.folders.google_folder.folders["staging"]'
terraform state mv module.folders.google_folder.folders[2] 'module.folders.google_folder.folders["production"]'
```