### PR TITLE
changes var.parent to a first class expression

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ locals {
 resource "google_folder" "folders" {
   count        = length(var.names)
   display_name = "${local.prefix}${element(var.names, count.index)}"
-  parent       = "${var.parent}"
+  parent       = var.parent
 }
 
 # give project creation access to service accounts


### PR DESCRIPTION
As of Terraform v0.12 interpolation is not required. This resolves the warning: "Interpolation-only expressions are deprecated".