### PR TITLE
Update CHANGELOG for v2.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.0.2] - 2020-01-10
+
 ### Fixed
 
+- Change `var.parent` to a first class expression. [#8b79ea0]
 - Fixed error with outputs after removing folders. [#16]
 
 ## [2.0.1] - 2019-11-05
@@ -41,11 +44,13 @@ and this project adheres to
 
 - Initial release
 
-[Unreleased]: https://github.com/terraform-google-modules/terraform-google-folders/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/terraform-google-modules/terraform-google-folders/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/terraform-google-modules/terraform-google-folders/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/terraform-google-modules/terraform-google-folders/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/terraform-google-modules/terraform-google-folders/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/terraform-google-modules/terraform-google-folders/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/terraform-google-modules/terraform-google-folders/releases/tag/v0.1.0
+[#8b79ea0]: https://github.com/terraform-google-modules/terraform-google-folders/commit/8b79ea0fbd1ae4152c06e263522db75e7cdbd6e6
 [#16]: https://github.com/terraform-google-modules/terraform-google-folders/issues/16
 [#19]: https://github.com/terraform-google-modules/terraform-google-folders/pull/19
 [#9]: https://github.com/terraform-google-modules/terraform-google-folders/pull/9


### PR DESCRIPTION
Release fixes to `var.parent` and outputs.