### PR TITLE
fix: relax version constraints to enable terraform 0.13.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The resources/services/activations/deletions that this module will create/trigge
   and need a Terraform 0.11.x-compatible version of this module, the last released version intended for
   Terraform 0.11.x is [0.1.0](https://registry.terraform.io/modules/terraform-google-modules/folders/google/0.1.0).
 
-
 ## Usage
 
 Basic usage of this module is as follows:
@@ -21,7 +20,7 @@ Basic usage of this module is as follows:
 ```hcl
 module "folders" {
   source  = "terraform-google-modules/folders/google"
-  version = "~> 2.0"
+  version = "~> 3.36.0"
 
   parent  = "folders/65552901371"
 

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -38,4 +38,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.7"
+  version = "~> 3.36.0"
 }
 
 module "folders" {

--- a/examples/simple_example/versions.tf
+++ b/examples/simple_example/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,6 +15,7 @@
 ---
 driver:
   name: terraform
+  verify_version: false
 
 provisioner:
   name: terraform

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 locals {

--- a/test/fixtures/simple_example/variables.tf
+++ b/test/fixtures/simple_example/variables.tf
@@ -49,7 +49,7 @@ variable "all_folder_admins" {
   type        = list(string)
   description = "List of IAM-style members that will get the extended permissions across all the folders."
   default = [
-    "group:gcp-global-cicd@apszaz.com",
+    "group:test-gcp-org-admins@test.infra.cft.tips",
   ]
 }
 

--- a/test/fixtures/simple_example/variables.tf
+++ b/test/fixtures/simple_example/variables.tf
@@ -39,9 +39,9 @@ variable "per_folder_admins" {
   type        = list(string)
   description = "List of IAM-style members per folder who will get extended permissions."
   default = [
-    "group:gcp-ddt-developers@apszaz.com",
-    "group:gcp-ddt-qa@apszaz.com",
-    "group:gcp-ddt-ops@apszaz.com",
+    "group:test-gcp-developers@test.infra.cft.tips",
+    "group:test-gcp-qa@test.infra.cft.tips",
+    "group:test-gcp-ops@test.infra.cft.tips",
   ]
 }
 

--- a/test/fixtures/simple_example/versions.tf
+++ b/test/fixtures/simple_example/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -26,11 +26,12 @@ module "folders-project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 9.0"
 
-  name              = "ci-folders"
-  random_project_id = "true"
-  org_id            = var.org_id
-  folder_id         = google_folder.ephemeral.name
-  billing_account   = var.billing_account
+  name                 = "ci-folders"
+  random_project_id    = "true"
+  org_id               = var.org_id
+  folder_id            = google_folder.ephemeral.name
+  billing_account      = var.billing_account
+  skip_gcloud_download = true
 
   activate_apis = [
     "cloudresourcemanager.googleapis.com",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -24,7 +24,7 @@ resource "google_folder" "ephemeral" {
 
 module "folders-project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 3.0"
+  version = "~> 9.0"
 
   name              = "ci-folders"
   random_project_id = "true"

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.13.0"
+  version = "~> 3.36.0"
 }
 
 provider "google-beta" {
-  version = "~> 2.13.0"
+  version = "~> 3.36.0"
 }

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/versions.tf
+++ b/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }


### PR DESCRIPTION
## What is this change?

This change relaxes terraform version requirements, enabling terraform 0.13.x to use this module again.

## Why make this change?

This is a stopgap change intended to bridge the transition between terraform 0.12.x and 0.13.y.