### PR TITLE
fix: Add support for conditional per_folder_admins and all_folder_adm…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ locals {
     ]
   ])
 
-  # Handle roles for all_folder_admins if provided, applied to all folders
+  # Handle roles for all_folder_admins if provided, applied to all folders only if they are not part of per_folder_admins
   folder_admin_roles_all_folders = flatten([
     for folder in var.names : [
       for role in var.folder_admin_roles : {
@@ -39,10 +39,11 @@ locals {
         members = var.all_folder_admins
       }
     ]
-    if length(var.all_folder_admins) > 0 # Only add roles if all_folder_admins is provided
+    # Only add roles for all_folder_admins if they are not already present in per_folder_admins
+    if length(var.all_folder_admins) > 0 && !contains(keys(var.per_folder_admins), folder)
   ])
 
-  # Merge per_folder_admins and all_folder_admins
+  # Merge per_folder_admins and all_folder_admins, avoiding duplication
   folder_admin_roles_combined = [
     for role_map in concat(local.folder_admin_roles_map_data, local.folder_admin_roles_all_folders) : role_map
   ]
@@ -59,14 +60,18 @@ resource "google_folder" "folders" {
 # give project creation access to service accounts
 # https://cloud.google.com/resource-manager/docs/access-control-folders#granting_folder-specific_roles_to_enable_project_creation
 
-resource "google_folder_iam_binding" "owners_combined" {
-  for_each = var.set_roles && length(local.folder_admin_roles_combined) > 0 ? zipmap([for i, v in local.folder_admin_roles_combined : i], local.folder_admin_roles_combined) : {}
-  folder   = google_folder.folders[each.value.name].name
-  role     = each.value.role
-
-  members = distinct(concat(
-    each.value.members,
-    contains(var.names, each.value.name) ? var.all_folder_admins : []
-  ))
+locals {
+  folder_iam_bindings = var.set_roles && length(local.folder_admin_roles_combined) > 0 ? { for i, role in local.folder_admin_roles_combined : "${role.name}-${role.role}" => role }: {}
 }
 
+resource "google_folder_iam_binding" "owners_combined" {
+  for_each = local.folder_iam_bindings
+
+  folder = google_folder.folders[each.value.name].name
+  role   = each.value.role
+
+  members = distinct(flatten([
+    each.value.members,
+    length(var.all_folder_admins) > 0 && contains(var.names, each.value.name) ? var.all_folder_admins : []
+  ]))
+}

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ resource "google_folder" "folders" {
 # https://cloud.google.com/resource-manager/docs/access-control-folders#granting_folder-specific_roles_to_enable_project_creation
 
 resource "google_folder_iam_binding" "owners_combined" {
-  for_each = var.set_roles && length(local.folder_admin_roles_combined) > 0 ? zipmap([for i, v in local.folder_admin_roles_combined : "${i}"], local.folder_admin_roles_combined) : {}
+  for_each = var.set_roles && length(local.folder_admin_roles_combined) > 0 ? zipmap([for i, v in local.folder_admin_roles_combined : i], local.folder_admin_roles_combined) : {}
   folder   = google_folder.folders[each.value.name].name
   role     = each.value.role
 

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "google_folder" "folders" {
 # https://cloud.google.com/resource-manager/docs/access-control-folders#granting_folder-specific_roles_to_enable_project_creation
 
 locals {
-  folder_iam_bindings = var.set_roles && length(local.folder_admin_roles_combined) > 0 ? { for i, role in local.folder_admin_roles_combined : "${role.name}-${role.role}" => role }: {}
+  folder_iam_bindings = var.set_roles && length(local.folder_admin_roles_combined) > 0 ? { for i, role in local.folder_admin_roles_combined : "${role.name}-${role.role}" => role } : {}
 }
 
 resource "google_folder_iam_binding" "owners_combined" {


### PR DESCRIPTION
Issue reported by other user as well earlier : https://github.com/terraform-google-modules/terraform-google-folders/issues/69

### Overview:
This PR introduces a modification to the existing IAM bindings for Google Folders. It enables the ability to conditionally apply `per_folder_admins` and `all_folder_admins` roles based on user input.

**Current Issue : If you have not provided per_folder_admins then even if you apple "all_folder_admins" still it does not apply that. So this PR is to fix that issue, because there can be requirement to add one DL or group of admins of all folders.**

### Changes:
1. **Logic:**
   - If `per_folder_admins` is provided, it applies to specific folders.
   - If `per_folder_admins` is not provided, it will be skipped.
   - `all_folder_admins` is applied to all folders if provided.
   - If `all_folder_admins` is not provided, it is skipped.

2. **Logic for Roles:**
   - If roles are not provided in `per_folder_admins`, it defaults to the `folder_admin_roles` list.
   
   #### Example:

```hcl
module "folders" {
  source  = "terraform-google-modules/folders/google"
  version = "~> 5.0"

  parent              = "organizations/${var.org_id}"
  names               = ["Core", "Prod"]
  deletion_protection = false
  set_roles           = true

  folder_admin_roles = [
    "roles/owner",
    "roles/resourcemanager.projectCreator",
  ]

  per_folder_admins = {
    Core = {
      members = ["group:admin-core@example.com"]
    }
  }

  all_folder_admins = ["group:admin-all@example.com"]
}