### PR TITLE
feat(folder-iam): Allow selecting authoritative/additive mode for admin roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Functional examples are included in the
 | all\_folder\_admins | List of IAM-style members that will get the extended permissions across all the folders. | `list(string)` | `[]` | no |
 | deletion\_protection | Prevent Terraform from destroying or recreating the folder. | `bool` | `true` | no |
 | folder\_admin\_roles | List of roles that will be applied to a folder if roles are not explictly specified in per\_folder\_admins | `list(string)` | <pre>[<br>  "roles/owner",<br>  "roles/resourcemanager.folderViewer",<br>  "roles/resourcemanager.projectCreator",<br>  "roles/compute.networkAdmin"<br>]</pre> | no |
+| mode | Mode for adding the IAM policies/bindings. 'authoritative' uses google\_folder\_iam\_binding (replaces existing members for the role); 'additive' uses google\_folder\_iam\_member (adds members without removing others). | `string` | `"authoritative"` | no |
 | names | Folder names. | `list(string)` | `[]` | no |
 | parent | The resource name of the parent Folder or Organization. Must be of the form folders/folder\_id or organizations/org\_id | `string` | n/a | yes |
 | per\_folder\_admins | IAM-style roles per members per folder who will get extended permissions. If roles are not provided for a folder/member combination, the list provided as `folder_admin_roles` will be applied as default. | <pre>map(object({<br>    members = list(string)<br>    roles   = optional(list(string))<br>  }))</pre> | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -69,3 +69,14 @@ variable "deletion_protection" {
   description = "Prevent Terraform from destroying or recreating the folder."
   default     = true
 }
+
+variable "mode" {
+  description = "Mode for adding the IAM policies/bindings. 'authoritative' uses google_folder_iam_binding (replaces existing members for the role); 'additive' uses google_folder_iam_member (adds members without removing others)."
+  type        = string
+  default     = "authoritative"
+
+  validation {
+    condition     = contains(["authoritative", "additive"], var.mode)
+    error_message = "The mode variable must be either 'authoritative' or 'additive'."
+  }
+}


### PR DESCRIPTION
## Implement Configurable IAM Mode for Folder Admin Role Assignments

### Summary

This merge request introduces a new variable `mode` that allows users to specify whether folder administrator IAM roles should be managed using `google_folder_iam_binding` (authoritative mode) or `google_folder_iam_member` (additive mode).

### Motivation

Previously, this module only used `google_folder_iam_binding` to assign folder admin roles. While effective for defining the complete set of members for a specific role, this authoritative approach may not be suitable for all use cases. Some users may prefer an additive approach using `google_folder_iam_member`, which allows assigning roles to individual members without removing other existing members for that role that might have been assigned outside of Terraform.

Introducing a configurable mode provides greater flexibility to align the module's behavior with different organizational IAM management strategies.

### Changes

-   Added a new variable `mode` (string, default: `"authoritative"`) to control the IAM resource type.
-   Included validation for the `mode` variable to ensure it is set to either `"authoritative"` or `"additive"`.
-   Modified the resource block to conditionally instantiate either `google_folder_iam_binding.owners_combined` or `google_folder_iam_member.owner_member` based on the value of `var.mode` using the `for_each` argument.
-   Introduced a new local `folder_iam_member_entries` to structure the combined role/member data appropriately for the `google_folder_iam_member` resource (one entry per folder, per role, per member).
-   The existing local `folder_iam_bindings_data` (derived from `folder_admin_roles_combined`) is used for the `google_folder_iam_binding` resource.

### Impact

-   When `mode` is `"authoritative"` (default), the module behaves as it did previously, managing roles using `google_folder_iam_binding`.
-   When `mode` is `"additive"`, the module will manage roles using `google_folder_iam_member`.
-   **Important:** Switching the `mode` variable for existing resources will cause Terraform to **destroy** the old IAM resource type (`_binding` or `_member`) and **create** the new one. Review the `terraform plan` output carefully when changing this value on deployed infrastructure, as the state management differs significantly between the two resource types.
